### PR TITLE
Update Tile Deck Generation and Expand Scoring Logic

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=SE2-SS2025-CARCASSONNE_CarcasonnneBackend
+sonar.projectKey=SE2-SS2025-CARCASSONNE_CarcassonneBackend
 sonar.organization=se2-ss2025-carcassonne
 sonar.host.url=https://sonarcloud.io
 sonar.sources=src

--- a/src/main/kotlin/com/carcassonne/backend/model/Tile.kt
+++ b/src/main/kotlin/com/carcassonne/backend/model/Tile.kt
@@ -7,7 +7,8 @@ data class Tile(
     val terrainWest: TerrainType,
     val tileRotation: TileRotation,
     val position: Position? = null,
-    val hasMonastery: Boolean = false
+    val hasMonastery: Boolean = false,
+    val count: Int
 )
 
 fun Tile.getAllTerrains(): Set<TerrainType> = setOf(
@@ -62,9 +63,7 @@ enum class TerrainType {
     ROAD,
     CITY,
     MONASTERY,
-    FIELD,
-    RIVER,
-    GARDEN
+    FIELD
 }
 
 enum class TileRotation {

--- a/src/main/kotlin/com/carcassonne/backend/model/Tile.kt
+++ b/src/main/kotlin/com/carcassonne/backend/model/Tile.kt
@@ -8,7 +8,8 @@ data class Tile(
     val tileRotation: TileRotation,
     val position: Position? = null,
     val hasMonastery: Boolean = false,
-    val count: Int
+    val hasShield: Boolean = false,
+    val count: Int = 1
 )
 
 fun Tile.getAllTerrains(): Set<TerrainType> = setOf(

--- a/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
+++ b/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
@@ -13,233 +13,16 @@ class GameManager {
 
     // Function to create a shuffled tile deck
     fun createShuffledTileDeck(seed: Long): List<Tile> {
-        // Save all 24 unique game tiles in a list for tile deck generation
-        val uniqueTiles = listOf(
-            Tile(
-                id = "tile-a-2",
-                terrainNorth = TerrainType.FIELD,
-                terrainEast = TerrainType.FIELD,
-                terrainSouth = TerrainType.ROAD,
-                terrainWest = TerrainType.FIELD,
-                tileRotation = TileRotation.NORTH,
-                hasMonastery = true,
-                count = 2
-            ),
-            Tile(
-                id = "tile-b-4",
-                terrainNorth = TerrainType.FIELD,
-                terrainEast = TerrainType.FIELD,
-                terrainSouth = TerrainType.FIELD,
-                terrainWest = TerrainType.FIELD,
-                tileRotation = TileRotation.NORTH,
-                hasMonastery = true,
-                count = 4
-            ),
-            Tile(
-                id = "tile-c-1",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.CITY,
-                terrainSouth = TerrainType.CITY,
-                terrainWest = TerrainType.CITY,
-                tileRotation = TileRotation.NORTH,
-                count = 1
-            ),
-            Tile(
-                id = "tile-d-4",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.ROAD,
-                terrainSouth = TerrainType.FIELD,
-                terrainWest = TerrainType.ROAD,
-                tileRotation = TileRotation.NORTH,
-                count = 4
-            ),
-            Tile(
-                id = "tile-e-5",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.FIELD,
-                terrainSouth = TerrainType.FIELD,
-                terrainWest = TerrainType.FIELD,
-                tileRotation = TileRotation.NORTH,
-                count = 5
-            ),
-            Tile(
-                id = "tile-f-2",
-                terrainNorth = TerrainType.FIELD,
-                terrainEast = TerrainType.CITY,
-                terrainSouth = TerrainType.FIELD,
-                terrainWest = TerrainType.CITY,
-                tileRotation = TileRotation.NORTH,
-                count = 2
-            ),
-            Tile(
-                id = "tile-g-1",
-                terrainNorth = TerrainType.FIELD,
-                terrainEast = TerrainType.CITY,
-                terrainSouth = TerrainType.FIELD,
-                terrainWest = TerrainType.CITY,
-                tileRotation = TileRotation.NORTH,
-                count = 1
-            ),
-            Tile(
-                id = "tile-h-3",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.FIELD,
-                terrainSouth = TerrainType.CITY,
-                terrainWest = TerrainType.FIELD,
-                tileRotation = TileRotation.NORTH,
-                count = 3
-            ),
-            Tile(
-                id = "tile-i-2",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.FIELD,
-                terrainSouth = TerrainType.FIELD,
-                terrainWest = TerrainType.CITY,
-                tileRotation = TileRotation.NORTH,
-                count = 2
-            ),
-            Tile(
-                id = "tile-j-3",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.ROAD,
-                terrainSouth = TerrainType.ROAD,
-                terrainWest = TerrainType.FIELD,
-                tileRotation = TileRotation.NORTH,
-                count = 3
-            ),
-            Tile(
-                id = "tile-k-3",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.FIELD,
-                terrainSouth = TerrainType.ROAD,
-                terrainWest = TerrainType.ROAD,
-                tileRotation = TileRotation.NORTH,
-                count = 3
-            ),
-            Tile(
-                id = "tile-m-3",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.ROAD,
-                terrainSouth = TerrainType.ROAD,
-                terrainWest = TerrainType.ROAD,
-                tileRotation = TileRotation.NORTH,
-                count = 3
-            ),
-            Tile(
-                id = "tile-n-3",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.CITY,
-                terrainSouth = TerrainType.FIELD,
-                terrainWest = TerrainType.FIELD,
-                tileRotation = TileRotation.NORTH,
-                count = 3
-            ),
-            Tile(
-                id = "tile-o-2",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.CITY,
-                terrainSouth = TerrainType.FIELD,
-                terrainWest = TerrainType.FIELD,
-                tileRotation = TileRotation.NORTH,
-                count = 2
-            ),
-            Tile(
-                id = "tile-p-2",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.ROAD,
-                terrainSouth = TerrainType.ROAD,
-                terrainWest = TerrainType.CITY,
-                tileRotation = TileRotation.NORTH,
-                count = 2
-            ),
-            Tile(
-                id = "tile-q-3",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.ROAD,
-                terrainSouth = TerrainType.ROAD,
-                terrainWest = TerrainType.CITY,
-                tileRotation = TileRotation.NORTH,
-                count = 3
-            ),
-            Tile(
-                id = "tile-r-1",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.CITY,
-                terrainSouth = TerrainType.FIELD,
-                terrainWest = TerrainType.CITY,
-                tileRotation = TileRotation.NORTH,
-                count = 1
-            ),
-            Tile(
-                id = "tile-s-3",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.CITY,
-                terrainSouth = TerrainType.FIELD,
-                terrainWest = TerrainType.CITY,
-                tileRotation = TileRotation.NORTH,
-                count = 3
-            ),
-            Tile(
-                id = "tile-t-2",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.CITY,
-                terrainSouth = TerrainType.ROAD,
-                terrainWest = TerrainType.CITY,
-                tileRotation = TileRotation.NORTH,
-                count = 2
-            ),
-            Tile(
-                id = "tile-u-1",
-                terrainNorth = TerrainType.CITY,
-                terrainEast = TerrainType.CITY,
-                terrainSouth = TerrainType.ROAD,
-                terrainWest = TerrainType.CITY,
-                tileRotation = TileRotation.NORTH,
-                count = 1
-            ),
-            Tile(
-                id = "tile-v-8",
-                terrainNorth = TerrainType.ROAD,
-                terrainEast = TerrainType.FIELD,
-                terrainSouth = TerrainType.ROAD,
-                terrainWest = TerrainType.FIELD,
-                tileRotation = TileRotation.NORTH,
-                count = 8
-            ),
-            Tile(
-                id = "tile-w-9",
-                terrainNorth = TerrainType.FIELD,
-                terrainEast = TerrainType.FIELD,
-                terrainSouth = TerrainType.ROAD,
-                terrainWest = TerrainType.ROAD,
-                tileRotation = TileRotation.NORTH,
-                count = 9
-            ),
-            Tile(
-                id = "tile-x-4",
-                terrainNorth = TerrainType.FIELD,
-                terrainEast = TerrainType.ROAD,
-                terrainSouth = TerrainType.ROAD,
-                terrainWest = TerrainType.ROAD,
-                tileRotation = TileRotation.NORTH,
-                count = 4
-            ),
-            Tile(
-                id = "tile-y-1",
-                terrainNorth = TerrainType.ROAD,
-                terrainEast = TerrainType.ROAD,
-                terrainSouth = TerrainType.ROAD,
-                terrainWest = TerrainType.ROAD,
-                tileRotation = TileRotation.NORTH,
-                count = 1
-            )
-        )
+        val uniqueTiles = getUniqueTiles()
 
-        // Populate tile deck with tiles in their respective amounts (72 in total)
+        // Populate tile deck with base tiles in their respective amounts (72 in total)
         val tiles = mutableListOf<Tile>()
         for (tile in uniqueTiles) {
-            repeat(tile.count) {
-                tiles.add(tile)
+            repeat(tile.count) { index ->
+                // Create unique id for every tile instance by appending index to base tile id
+                val uniqueId = "${tile.id}-$index"
+                val tileWithId = tile.copy(id = uniqueId)
+                tiles.add(tileWithId)
             }
         }
 
@@ -318,8 +101,8 @@ class GameManager {
     private fun awardPoints(
         game: GameState,
         involvedMeeples: MutableList<Meeple>, //MutableList für Konsistenz
-        basePoints: Int,  //Weniger Punkte , hilft bei Engame Logik zum Beispiel ...
-        featureType: String //Berechnung für Monestary , Road , City
+        basePoints: Int,  //Weniger Punkte, hilft bei Endgame Logik zum Beispiel ...
+        featureType: String //Berechnung für Monestary, Road, City
          ) {
     // Überprüfung ob Meeples vorhanden sind und Punkte vergeben werden können
     if (involvedMeeples.isEmpty()) {
@@ -354,6 +137,10 @@ class GameManager {
             println("Ungültiger Feature-Typ: $featureType")
             0
         }
+    }
+
+    if (featureType == "CITY") {
+
     }
 
     // Punkte verteilen mit Spieler-Check
@@ -723,5 +510,236 @@ class GameManager {
         game.players.add(host) //host übergabe
         games[gameId] = game
         return game
+    }
+
+    fun getUniqueTiles(): List<Tile> {
+        // Save all 24 unique base tiles in a list for tile deck generation
+        val uniqueTiles = listOf(
+            Tile(
+                id = "tile-a",
+                terrainNorth = TerrainType.FIELD,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                hasMonastery = true,
+                count = 2
+            ),
+            Tile(
+                id = "tile-b",
+                terrainNorth = TerrainType.FIELD,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                hasMonastery = true,
+                count = 4
+            ),
+            Tile(
+                id = "tile-c",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.CITY,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                hasShield = true,
+                count = 1
+            ),
+            Tile(
+                id = "tile-d",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.ROAD,
+                tileRotation = TileRotation.NORTH,
+                count = 4
+            ),
+            Tile(
+                id = "tile-e",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                count = 5
+            ),
+            Tile(
+                id = "tile-f",
+                terrainNorth = TerrainType.FIELD,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                hasShield = true,
+                count = 2
+            ),
+            Tile(
+                id = "tile-g",
+                terrainNorth = TerrainType.FIELD,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 1
+            ),
+            Tile(
+                id = "tile-h",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.CITY,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-i",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 2
+            ),
+            Tile(
+                id = "tile-j",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-k",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.ROAD,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-m",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.ROAD,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-n",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-o",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                hasShield = true,
+                count = 2
+            ),
+            Tile(
+                id = "tile-p",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                hasShield = true,
+                count = 2
+            ),
+            Tile(
+                id = "tile-q",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-r",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                hasShield = true,
+                count = 1
+            ),
+            Tile(
+                id = "tile-s",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-t",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                hasShield = true,
+                count = 2
+            ),
+            Tile(
+                id = "tile-u",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 1
+            ),
+            Tile(
+                id = "tile-v",
+                terrainNorth = TerrainType.ROAD,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                count = 8
+            ),
+            Tile(
+                id = "tile-w",
+                terrainNorth = TerrainType.FIELD,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.ROAD,
+                tileRotation = TileRotation.NORTH,
+                count = 9
+            ),
+            Tile(
+                id = "tile-x",
+                terrainNorth = TerrainType.FIELD,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.ROAD,
+                tileRotation = TileRotation.NORTH,
+                count = 4
+            ),
+            Tile(
+                id = "tile-y",
+                terrainNorth = TerrainType.ROAD,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.ROAD,
+                tileRotation = TileRotation.NORTH,
+                count = 1
+            )
+        )
+        return uniqueTiles
     }
 }

--- a/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
+++ b/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
@@ -130,17 +130,19 @@ class GameManager {
 
     // Punkteberechnung mit enum für Klarheit
     val pointsPerFeature = when (featureType) {
-        "CITY" -> basePoints * 2
+        "CITY" -> {
+            var points = basePoints * 2
+            // Add shield bonus of 2 points for applicable city tiles
+            val tilesWithShield = getTilesWithShield(involvedMeeples, game)
+            points += tilesWithShield.size * 2
+            points
+        }
         "ROAD" -> basePoints
         "MONASTERY" -> basePoints
         else -> {
             println("Ungültiger Feature-Typ: $featureType")
             0
         }
-    }
-
-    if (featureType == "CITY") {
-
     }
 
     // Punkte verteilen mit Spieler-Check
@@ -160,6 +162,7 @@ class GameManager {
            ${winners.joinToString { "$it (${playerCounts[it]} Meeples)" }}"""
     )
 }
+
     fun endGame(gameId: String): String {
         val game = games[gameId] ?: throw IllegalArgumentException("Game not found")
 
@@ -217,7 +220,6 @@ class GameManager {
                 println("City is completed at ${tile.position}")
             }
         }
-
 
         //game.nextPlayer() move to endTurn logic
         return game
@@ -741,5 +743,22 @@ class GameManager {
             )
         )
         return uniqueTiles
+    }
+
+    fun getTilesWithShield(involvedMeeples: List<Meeple>, gameState: GameState): List<Tile> {
+        val tilesWithShield = mutableListOf<Tile>()
+
+        // Add all tiles with shield to the list (no need to manually check for city)
+        for (tile in gameState.tileDeck) {
+            if (tile.hasShield) {
+                for (meeple in involvedMeeples) {
+                    if (meeple.tileId == tile.id) {
+                        tilesWithShield.add(tile)
+                        break // Exit inner loop upon match
+                    }
+                }
+            }
+        }
+        return tilesWithShield
     }
 }

--- a/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
+++ b/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
@@ -13,30 +13,238 @@ class GameManager {
 
     // Function to create a shuffled tile deck
     fun createShuffledTileDeck(seed: Long): List<Tile> {
-        // Generate a predefined set of tiles (for demonstration)
-        val predefinedTiles = mutableListOf<Tile>()
+        // Save all 24 unique game tiles in a list for tile deck generation
+        val uniqueTiles = listOf(
+            Tile(
+                id = "tile-a-2",
+                terrainNorth = TerrainType.FIELD,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                hasMonastery = true,
+                count = 2
+            ),
+            Tile(
+                id = "tile-b-4",
+                terrainNorth = TerrainType.FIELD,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                hasMonastery = true,
+                count = 4
+            ),
+            Tile(
+                id = "tile-c-1",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.CITY,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 1
+            ),
+            Tile(
+                id = "tile-d-4",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.ROAD,
+                tileRotation = TileRotation.NORTH,
+                count = 4
+            ),
+            Tile(
+                id = "tile-e-5",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                count = 5
+            ),
+            Tile(
+                id = "tile-f-2",
+                terrainNorth = TerrainType.FIELD,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 2
+            ),
+            Tile(
+                id = "tile-g-1",
+                terrainNorth = TerrainType.FIELD,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 1
+            ),
+            Tile(
+                id = "tile-h-3",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.CITY,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-i-2",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 2
+            ),
+            Tile(
+                id = "tile-j-3",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-k-3",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.ROAD,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-m-3",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.ROAD,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-n-3",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-o-2",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                count = 2
+            ),
+            Tile(
+                id = "tile-p-2",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 2
+            ),
+            Tile(
+                id = "tile-q-3",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-r-1",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 1
+            ),
+            Tile(
+                id = "tile-s-3",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.FIELD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 3
+            ),
+            Tile(
+                id = "tile-t-2",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 2
+            ),
+            Tile(
+                id = "tile-u-1",
+                terrainNorth = TerrainType.CITY,
+                terrainEast = TerrainType.CITY,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.CITY,
+                tileRotation = TileRotation.NORTH,
+                count = 1
+            ),
+            Tile(
+                id = "tile-v-8",
+                terrainNorth = TerrainType.ROAD,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.FIELD,
+                tileRotation = TileRotation.NORTH,
+                count = 8
+            ),
+            Tile(
+                id = "tile-w-9",
+                terrainNorth = TerrainType.FIELD,
+                terrainEast = TerrainType.FIELD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.ROAD,
+                tileRotation = TileRotation.NORTH,
+                count = 9
+            ),
+            Tile(
+                id = "tile-x-4",
+                terrainNorth = TerrainType.FIELD,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.ROAD,
+                tileRotation = TileRotation.NORTH,
+                count = 4
+            ),
+            Tile(
+                id = "tile-y-1",
+                terrainNorth = TerrainType.ROAD,
+                terrainEast = TerrainType.ROAD,
+                terrainSouth = TerrainType.ROAD,
+                terrainWest = TerrainType.ROAD,
+                tileRotation = TileRotation.NORTH,
+                count = 1
+            )
+        )
 
-        // Populate predefined tiles
-        TerrainType.values().forEach { terrain ->
-            // For simplicity, create 5 tiles of each terrain type
-            repeat(5) {
-                predefinedTiles.add(
-                    Tile(
-                        id = "${terrain}_${it}",
-                        terrainNorth = terrain,
-                        terrainEast = terrain,
-                        terrainSouth = terrain,
-                        terrainWest = terrain,
-                        tileRotation = TileRotation.NORTH
-                    )
-                )
+        // Populate tile deck with tiles in their respective amounts (72 in total)
+        val tiles = mutableListOf<Tile>()
+        for (tile in uniqueTiles) {
+            repeat(tile.count) {
+                tiles.add(tile)
             }
         }
 
         // Shuffle tiles using a seed for consistent randomness
-        val shuffledDeck = predefinedTiles.shuffled(Random(seed))
-
-        return shuffledDeck
+        return tiles.shuffled(Random(seed))
     }
 
     // Function to draw a tile for the current player

--- a/src/test/kotlin/com/carcassonne/backend/service/GameManagerTest.kt
+++ b/src/test/kotlin/com/carcassonne/backend/service/GameManagerTest.kt
@@ -28,7 +28,7 @@ class GameManagerTest {
     @Test
     fun `should generate tile deck with correct count and valid terrains`() {
         val deck = gameManager.createShuffledTileDeck(seed = 99L)
-        val expectedCount = TerrainType.values().size * 5
+        val expectedCount = gameManager.getUniqueTiles().sumOf { it.count }
         assertEquals(expectedCount, deck.size, "Expected $expectedCount tiles in deck")
 
         deck.forEach { tile ->


### PR DESCRIPTION
Implemented full Carcassonne tile deck by defining all 24 unique tiles with correct counts and terrain features. Ensured each tile instance receives unique ID to differentiate between visually identical tiles.

Refactored tile generation in GameManager and updated GameManagerTest by moving tile definitions to a separate getUniqueTiles() method for reusability.

Expanded scoring logic to support shield bonus on city tiles by filtering tiles with hasShield from placed meeples, awarding +2 points per shield to players during city scoring.