### PR TITLE
Updated websocket to ensure full lobby sync and determine host

### DIFF
--- a/src/main/kotlin/com/carcassonne/backend/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/carcassonne/backend/config/WebSocketConfig.kt
@@ -19,7 +19,8 @@ class WebSocketConfig(
     }
 
     override fun configureMessageBroker(registry: MessageBrokerRegistry) {
-        registry.enableSimpleBroker("/topic")
+        registry.enableSimpleBroker("/topic", "/queue") //Add "/queue" for private messaging
         registry.setApplicationDestinationPrefixes("/app")
+        registry.setUserDestinationPrefix("/user")
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.datasource.url=jdbc:postgresql://localhost:5432/carcassonne
 
-spring.datasource.username=casscaronneUser
-spring.datasource.password=carcassonne123
+spring.datasource.username=postgres
+spring.datasource.password=admin
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true

--- a/src/test/kotlin/com/carcassonne/backend/controller/GameWebSocketControllerTest.kt
+++ b/src/test/kotlin/com/carcassonne/backend/controller/GameWebSocketControllerTest.kt
@@ -6,56 +6,62 @@ import com.carcassonne.backend.model.Player
 import com.carcassonne.backend.repository.GameRepository
 import com.carcassonne.backend.service.GameManager
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
+import org.mockito.kotlin.*
 import org.springframework.messaging.simp.SimpMessagingTemplate
-import kotlin.test.assertEquals
 
 class GameWebSocketControllerTest {
 
-    private val mockGameManager = mock(GameManager::class.java)
-    private val mockMessagingTemplate = mock(SimpMessagingTemplate::class.java)
-    private val mockGameRepository = mock(GameRepository::class.java)
+    private val mockGameManager = mock<GameManager>()
+    private val mockMessagingTemplate = mock<SimpMessagingTemplate>()
+    private val mockGameRepository = mock<GameRepository>()
 
     private val controller = GameWebSocketController(mockGameManager, mockMessagingTemplate, mockGameRepository)
 
     @Test
-    fun `handle join_game sends player_joined message`() {
+    fun `handle join_game sends player_joined message to all and privately`() {
         // Arrange
         val gameId = "testgame"
-        val player= "Player"
+        val playerName = "Player"
 
-        val playersList = mutableListOf<Player>()
+        val player = Player(id = playerName, score = 0, remainingMeeple = 7, user_id = null)
+        val playersList = mutableListOf(player)
 
-        // Create a mock GameState
-        val mockGameState = mock(GameState::class.java)
+        val mockGameState = mock<GameState> {
+            on { players } doReturn playersList
+            on { getCurrentPlayer() } doReturn playerName
+        }
 
-        `when`(mockGameState.players).thenReturn(playersList)
-        `when`(mockGameState.getCurrentPlayer()).thenReturn(player)
-        `when`(mockGameManager.getOrCreateGame(gameId)).thenReturn(mockGameState)
+        whenever(mockGameManager.getOrCreateGame(gameId)).thenReturn(mockGameState)
 
         val message = GameMessage(
             type = "join_game",
             gameId = gameId,
-            player = player //TODO : playerID Name change
+            player = playerName
         )
-
 
         // Act
         controller.handle(message)
 
-        // Assert
-        //assertEquals("Player",mockGameState.findPlayerById(player)?.id) TODO Testfall schreiben
+        // Assert: verify broadcast to all
+        argumentCaptor<Any>().apply {
+            verify(mockMessagingTemplate).convertAndSend(eq("/topic/game/$gameId"), capture())
 
-        verify(mockMessagingTemplate).convertAndSend(
-            eq("/topic/game/$gameId"),
-            argThat<Any> { payload ->
-                val map = payload as Map<*, *>
-                map["type"] == "player_joined" &&
-                        map["player"] == player
-                        //&&   //TODO PlayerID Name Change
-                        //(map["players"] as List<*>).contains(playerr)
+            val payload = firstValue as Map<*, *>
+            assert(payload["type"] == "player_joined")
+            assert(payload["currentPlayer"] == playerName)
+            assert(payload["host"] == playerName)
+            assert((payload["players"] as List<*>).contains(playerName))
+        }
+
+        // Assert: verify private message sent to user
+        verify(mockMessagingTemplate).convertAndSendToUser(
+            eq(playerName),
+            eq("/queue/private"),
+            check {
+                val payload = it as Map<*, *>
+                assert(payload["type"] == "player_joined")
+                assert(payload["host"] == playerName)
             }
         )
     }
 }
-


### PR DESCRIPTION
- Broadcast updated player list to all clients on every join, regardless of join order
- Added private /user/queue message for newly joined player to ensure reliable sync
- Included host ID in 'player_joined' payload to allow frontend to detect lobby owner
- Fixed inconsistent UI between host and joiners due to playerCount mismatch