### PR TITLE
feat: handle unplaceable tiles by skipping and ending game if needed

### DIFF
--- a/src/main/kotlin/com/carcassonne/backend/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/carcassonne/backend/config/WebSocketConfig.kt
@@ -19,7 +19,8 @@ class WebSocketConfig(
     }
 
     override fun configureMessageBroker(registry: MessageBrokerRegistry) {
-        registry.enableSimpleBroker("/topic")
+        registry.enableSimpleBroker("/topic", "/queue") //Add "/queue" for private messaging
         registry.setApplicationDestinationPrefixes("/app")
+        registry.setUserDestinationPrefix("/user")
     }
 }

--- a/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
+++ b/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
@@ -28,16 +28,25 @@ class GameManager {
     }
 
 
-    // Function to draw a tile for the current player
     fun drawTileForPlayer(gameId: String): Tile? {
         val game = games[gameId] ?: return null
-        val tile = game.drawTile() // Use the drawTile method from GameState to get a tile
-        if (tile != null) {
-            if (!canPlaceTileAnywhere(game, tile)) println("No legal placement possible. Skipping tile")
-            return tile
+
+        while (game.tileDeck.isNotEmpty()) {
+            val tile = game.drawTile()!!
+            if (canPlaceTileAnywhere(game, tile)) {
+                return tile
+            } else {
+                println("Tile ${tile.id} has no valid placement and is discarded")
+                // Optional: track discarded tiles if you want
+            }
         }
-        return null // Return null if no tile is available
+
+        // No tiles left that can be played
+        println("No more playable tiles in the deck")
+        game.finishGame() // or set status to SCORING if applicable
+        return null
     }
+
 
     fun canPlaceTileAnywhere(game: GameState, tile: Tile): Boolean {
         val terrainMap = tile.getRotatedTerrains()

--- a/src/test/kotlin/com/carcassonne/backend/controller/GameWebSocketControllerTest.kt
+++ b/src/test/kotlin/com/carcassonne/backend/controller/GameWebSocketControllerTest.kt
@@ -6,56 +6,62 @@ import com.carcassonne.backend.model.Player
 import com.carcassonne.backend.repository.GameRepository
 import com.carcassonne.backend.service.GameManager
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
+import org.mockito.kotlin.*
 import org.springframework.messaging.simp.SimpMessagingTemplate
-import kotlin.test.assertEquals
 
 class GameWebSocketControllerTest {
 
-    private val mockGameManager = mock(GameManager::class.java)
-    private val mockMessagingTemplate = mock(SimpMessagingTemplate::class.java)
-    private val mockGameRepository = mock(GameRepository::class.java)
+    private val mockGameManager = mock<GameManager>()
+    private val mockMessagingTemplate = mock<SimpMessagingTemplate>()
+    private val mockGameRepository = mock<GameRepository>()
 
     private val controller = GameWebSocketController(mockGameManager, mockMessagingTemplate, mockGameRepository)
 
     @Test
-    fun `handle join_game sends player_joined message`() {
+    fun `handle join_game sends player_joined message to all and privately`() {
         // Arrange
         val gameId = "testgame"
-        val player= "Player"
+        val playerName = "Player"
 
-        val playersList = mutableListOf<Player>()
+        val player = Player(id = playerName, score = 0, remainingMeeple = 7, user_id = null)
+        val playersList = mutableListOf(player)
 
-        // Create a mock GameState
-        val mockGameState = mock(GameState::class.java)
+        val mockGameState = mock<GameState> {
+            on { players } doReturn playersList
+            on { getCurrentPlayer() } doReturn playerName
+        }
 
-        `when`(mockGameState.players).thenReturn(playersList)
-        `when`(mockGameState.getCurrentPlayer()).thenReturn(player)
-        `when`(mockGameManager.getOrCreateGame(gameId)).thenReturn(mockGameState)
+        whenever(mockGameManager.getOrCreateGame(gameId)).thenReturn(mockGameState)
 
         val message = GameMessage(
             type = "join_game",
             gameId = gameId,
-            player = player //TODO : playerID Name change
+            player = playerName
         )
-
 
         // Act
         controller.handle(message)
 
-        // Assert
-        //assertEquals("Player",mockGameState.findPlayerById(player)?.id) TODO Testfall schreiben
+        // Assert: verify broadcast to all
+        argumentCaptor<Any>().apply {
+            verify(mockMessagingTemplate).convertAndSend(eq("/topic/game/$gameId"), capture())
 
-        verify(mockMessagingTemplate).convertAndSend(
-            eq("/topic/game/$gameId"),
-            argThat<Any> { payload ->
-                val map = payload as Map<*, *>
-                map["type"] == "player_joined" &&
-                        map["player"] == player
-                        //&&   //TODO PlayerID Name Change
-                        //(map["players"] as List<*>).contains(playerr)
+            val payload = firstValue as Map<*, *>
+            assert(payload["type"] == "player_joined")
+            assert(payload["currentPlayer"] == playerName)
+            assert(payload["host"] == playerName)
+            assert((payload["players"] as List<*>).contains(playerName))
+        }
+
+        // Assert: verify private message sent to user
+        verify(mockMessagingTemplate).convertAndSendToUser(
+            eq(playerName),
+            eq("/queue/private"),
+            check {
+                val payload = it as Map<*, *>
+                assert(payload["type"] == "player_joined")
+                assert(payload["host"] == playerName)
             }
         )
     }
 }
-

--- a/src/test/kotlin/com/carcassonne/backend/service/GameManagerTest.kt
+++ b/src/test/kotlin/com/carcassonne/backend/service/GameManagerTest.kt
@@ -64,14 +64,27 @@ class GameManagerTest {
 
 
     @Test
-    fun `drawTileForPlayer should return tile if deck has tiles`() {
+    fun `drawTileForPlayer should return tile if deck has placeable tile`() {
         val game = gameManager.getOrCreateGame("game-draw")
+
+        // Place a starting tile at (0,0) so something is on the board
+        game.board[Position(0, 0)] = Tile(
+            id = "start-tile",
+            terrainNorth = TerrainType.ROAD,
+            terrainEast = TerrainType.FIELD,
+            terrainSouth = TerrainType.FIELD,
+            terrainWest = TerrainType.FIELD,
+            tileRotation = TileRotation.NORTH
+        )
+
+        // Add a tile that can connect to that starting tile
         val tile = Tile(
-            "${TerrainType.CITY}_${this}",
-            TerrainType.CITY, TerrainType.CITY,
-            TerrainType.CITY, TerrainType.ROAD,
-            TileRotation.NORTH,
-            Position(0,0)
+            id = "test-tile",
+            terrainNorth = TerrainType.FIELD,
+            terrainEast = TerrainType.ROAD,
+            terrainSouth = TerrainType.FIELD,
+            terrainWest = TerrainType.FIELD,
+            tileRotation = TileRotation.NORTH
         )
         game.tileDeck.add(tile)
 


### PR DESCRIPTION
Updated drawTileForPlayer() to:

Skip and discard unplaceable tiles

Continue drawing until a valid tile is found or the deck is empty

End the game if no playable tiles remain

Added logging for discarded tiles

Ensured game flow continues without dead turns

Adjusted tests in GameManagerTest.kt accordingly

