### PR TITLE
Feature: Backend support for Meeple placement & phase handling

### DIFF
--- a/src/main/kotlin/com/carcassonne/backend/controller/GameWebSocketController.kt
+++ b/src/main/kotlin/com/carcassonne/backend/controller/GameWebSocketController.kt
@@ -2,6 +2,7 @@ package com.carcassonne.backend.controller
 
 import com.carcassonne.backend.model.GameMessage
 import com.carcassonne.backend.model.GamePhase
+import com.carcassonne.backend.model.Meeple
 import com.carcassonne.backend.model.Position
 import com.carcassonne.backend.model.MeeplePosition
 import com.carcassonne.backend.repository.GameRepository
@@ -74,30 +75,53 @@ class GameWebSocketController(
 
             "place_tile" -> {
                 try {
-                    val game = gameManager.placeTile(msg.gameId!!, msg.tile!!, msg.player!!)
-                    val tile = msg.tile!!
-                    val position  = tile.position!!
-
-                    val payload = mapOf(
-                        "id" to tile.id,
-                        "terrainNorth" to tile.terrainNorth,
-                        "terrainEast" to tile.terrainEast,
-                        "terrainSouth" to tile.terrainSouth,
-                        "terrainWest" to tile.terrainWest,
-                        "tileRotation" to tile.tileRotation.name,
-                        "hasMonastery" to tile.hasMonastery,
-                        "hasShield" to tile.hasShield,
-                        "position" to mapOf("x" to position.x, "y" to position.y)
+                    // 1) Stein im GameManager platzieren (kann null liefern, falls ungültig)
+                    val game = gameManager.placeTile(
+                        msg.gameId!!,
+                        msg.tile!!,
+                        msg.player!!
                     )
 
-                    val boardUpdatePayload = mapOf(
-                        "type" to "board_update",
-                        "tile" to payload,
-                        "player" to mapOf("id" to msg.player)
-                    )
-                    messagingTemplate.convertAndSend("/topic/game/${msg.gameId}", boardUpdatePayload)
+                    // 2) Nur wenn das Spiel-Objekt zurückkam → Status in DB + Payload schicken
+                    game?.let { g ->
+
+                        // Status (z. B. MEEPLE_PLACEMENT) persistent speichern
+                        gameRepository.updateStatusByGameCode(
+                            msg.gameId,
+                            g.status.name
+                        )
+
+                        // 3) Daten für Board-Update zusammenstellen
+                        val tile      = msg.tile!!
+                        val pos       = tile.position!!
+
+                        val tileJson = mapOf(
+                            "id"           to tile.id,
+                            "terrainNorth" to tile.terrainNorth,
+                            "terrainEast"  to tile.terrainEast,
+                            "terrainSouth" to tile.terrainSouth,
+                            "terrainWest"  to tile.terrainWest,
+                            "tileRotation" to tile.tileRotation.name,
+                            "hasMonastery" to tile.hasMonastery,
+                            "hasShield"    to tile.hasShield,
+                            "position"     to mapOf("x" to pos.x, "y" to pos.y)
+                        )
+
+                        val boardUpdate = mapOf(
+                            "type"      to "board_update",
+                            "tile"      to tileJson,
+                            "player"    to mapOf("id" to msg.player),
+                            "gamePhase" to g.status.name
+                        )
+
+                        // 4) An alle Clients senden
+                        messagingTemplate.convertAndSend(
+                            "/topic/game/${msg.gameId}",
+                            boardUpdate
+                        )
+                    }
                 }
-                catch(e: Exception) {
+                catch (e: Exception) {
                     messagingTemplate.convertAndSend(
                         "/topic/game/${msg.gameId}",
                         mapOf("type" to "error", "message" to e.message)
@@ -106,39 +130,69 @@ class GameWebSocketController(
             }
 
             "place_meeple" -> {
+                // 1) Meeple aus dem Message-Objekt holen oder gleich Error zurück
                 val meeple = msg.meeple ?: run {
-                    val error = mapOf(
-                        "type" to "error",
-                        "message" to "Invalid meeple placement data"
+                    messagingTemplate.convertAndSend(
+                        "/topic/game/${msg.gameId}",
+                        mapOf("type" to "error", "message" to "Invalid meeple placement data")
                     )
-                    messagingTemplate.convertAndSend("/topic/game/${msg.gameId}", error)
                     return
                 }
 
+                // 2) Position einmal auf null prüfen und in ein val packen
+                val meeplePos = meeple.position ?: run {
+                    messagingTemplate.convertAndSend(
+                        "/topic/game/${msg.gameId}",
+                        mapOf("type" to "error", "message" to "Invalid meeple position")
+                    )
+                    return
+                }
+
+                // 3) Die Platzierung tatsächlich durchführen
                 val game = gameManager.placeMeeple(
-                    gameId = msg.gameId,
+                    gameId   = msg.gameId,
                     playerId = msg.player,
-                    meeple = meeple,
-                    position = meeple.position!!
+                    meeple   = meeple,
+                    position = meeplePos
                 )
 
                 if (game != null) {
-                    val placingPlayer = game.players.find { it.id == msg.player }
+                    gameRepository.updateStatusByGameCode(
+                        msg.gameId,
+                        game.status.name
+                    )
 
+                    // 4) Spieler holen, um remainingMeeple zu liefern
+                    val placingPlayer = game.players.first { it.id == msg.player }
+
+                    // 5) Aus dem Board die Position der betroffenen Kachel extrahieren
+                    val tileEntry = game.board.entries.first { (_, tile) ->
+                        tile.id == meeple.tileId
+                    }
+                    val tilePos = tileEntry.key
+
+                    // 6) Payload bauen und senden
                     val payload = mapOf(
-                        "type" to "meeple_placed",
-                        "meeple" to meeple,
-                        "player" to msg.player,
-                        "remainingMeeple" to placingPlayer?.remainingMeeple,
-                        "nextPlayer" to game.getCurrentPlayer() //TODO: Michael: ev. nicht notwendig, abstimmen mit Scoring-Logik
+                        "type"            to "meeple_placed",
+                        "meeple"          to mapOf(
+                            "id"       to meeple.id,
+                            "playerId" to meeple.playerId,
+                            "tileId"   to meeple.tileId,
+                            "position" to meeplePos.name, // N/E/S/W/C auf der Kachel
+                            "x"        to tilePos.x,      // Board-Koordinate
+                            "y"        to tilePos.y
+                        ),
+                        "player"          to msg.player,
+                        "remainingMeeple" to placingPlayer.remainingMeeple,
+                        "gamePhase"       to game.status.name
                     )
                     messagingTemplate.convertAndSend("/topic/game/${msg.gameId}", payload)
                 } else {
-                    val error = mapOf(
-                        "type" to "error",
-                        "message" to "Invalid meeple placement or not your turn"
+                    // 7) Ungültige Platzierung oder falscher Spieler
+                    messagingTemplate.convertAndSend(
+                        "/topic/game/${msg.gameId}",
+                        mapOf("type" to "error", "message" to "Invalid meeple placement or not your turn")
                     )
-                    messagingTemplate.convertAndSend("/topic/game/${msg.gameId}", error)
                 }
             }
 

--- a/src/main/kotlin/com/carcassonne/backend/controller/GameWebSocketController.kt
+++ b/src/main/kotlin/com/carcassonne/backend/controller/GameWebSocketController.kt
@@ -95,10 +95,13 @@ class GameWebSocketController(
                 )
 
                 if (game != null) {
+                    val placingPlayer = game.players.find { it.id == msg.player }
+
                     val payload = mapOf(
                         "type" to "meeple_placed",
                         "meeple" to meeple,
                         "player" to msg.player,
+                        "remainingMeeple" to placingPlayer?.remainingMeeple,
                         "nextPlayer" to game.getCurrentPlayer() //TODO: Michael: ev. nicht notwendig, abstimmen mit Scoring-Logik
                     )
                     messagingTemplate.convertAndSend("/topic/game/${msg.gameId}", payload)

--- a/src/main/kotlin/com/carcassonne/backend/model/GameMessage.kt
+++ b/src/main/kotlin/com/carcassonne/backend/model/GameMessage.kt
@@ -3,5 +3,6 @@ data class GameMessage(
     val type: String,        // "join_game", "place_tile"
     val gameId: String,
     val player: String,  // TODO: Spieler ID rename
-    val tile: Tile? = null
+    val tile: Tile? = null,
+    val meeple: Meeple? = null
 )

--- a/src/main/kotlin/com/carcassonne/backend/model/GameState.kt
+++ b/src/main/kotlin/com/carcassonne/backend/model/GameState.kt
@@ -46,7 +46,7 @@ data class GameState(
     // Add a player to the game
     fun addPlayer(player: String) {
         if (status == GamePhase.WAITING && players.size < 4) {
-            val playerr = Player(player,0,8,0)
+            val playerr = Player(player,0,7,0)
             players.add(playerr)
         } else {
             throw IllegalStateException("Game already started or max players reached")

--- a/src/main/kotlin/com/carcassonne/backend/model/Meeple.kt
+++ b/src/main/kotlin/com/carcassonne/backend/model/Meeple.kt
@@ -3,7 +3,7 @@ package com.carcassonne.backend.model
 data class Meeple(
     val id: String,                 // Eindeutige ID für jeden Meeple
     val playerId: String,           // ID des Spielers, dem der Meeple gehört
-    var type: MeepleType? = null,   // Erst beim Setzen zugewiesen
+    // var type: MeepleType? = null,   // Erst beim Setzen zugewiesen, brauchen wir wahrscheinlich gar nicht.
     var tileId: String? = null,     // ID der Kachel, auf der der Meeple platziert ist
     var position: MeeplePosition? = null // Position des Meeples auf der Kachel
 )

--- a/src/main/kotlin/com/carcassonne/backend/model/Player.kt
+++ b/src/main/kotlin/com/carcassonne/backend/model/Player.kt
@@ -3,7 +3,7 @@ package com.carcassonne.backend.model
 data class Player(
     val id: String,
     var score: Int,
-    val remainingMeeple: Int,
+    var remainingMeeple: Int,
     val user_id: Int?
 )
 

--- a/src/main/kotlin/com/carcassonne/backend/model/Tile.kt
+++ b/src/main/kotlin/com/carcassonne/backend/model/Tile.kt
@@ -63,14 +63,29 @@ fun Tile.getTerrainType(direction: String): TerrainType? {
     return rotatedTerrains[direction] // Gibt den TerrainType für die angegebene Richtung zurück
 }
 
-fun Tile.getTerrainAtOrNull(direction: MeeplePosition?): TerrainType? {
-    return direction?.let {
-        when (it) {
-            MeeplePosition.N -> getRotatedTerrains()["N"]
-            MeeplePosition.E  -> getRotatedTerrains()["E"]
-            MeeplePosition.S -> getRotatedTerrains()["S"]
-            MeeplePosition.W  -> getRotatedTerrains()["W"]
-            MeeplePosition.C -> TerrainType.MONASTERY
+fun Tile.getTerrainAtOrNull(pos: MeeplePosition): TerrainType? {
+    // Zuerst die Rotationslogik für N, E, S, W wiederverwenden
+    val terrains = getRotatedTerrains()
+    return when (pos) {
+        MeeplePosition.N -> terrains["N"]
+        MeeplePosition.E -> terrains["E"]
+        MeeplePosition.S -> terrains["S"]
+        MeeplePosition.W -> terrains["W"]
+        MeeplePosition.C -> when {
+            // Monastery sitzt immer in der Mitte
+            hasMonastery -> TerrainType.MONASTERY
+
+            // gerade durchgehende Straße West↔Ost
+            terrains["W"] == TerrainType.ROAD && terrains["E"] == TerrainType.ROAD -> TerrainType.ROAD
+            // gerade durchgehende Straße Nord↔Süd
+            terrains["N"] == TerrainType.ROAD && terrains["S"] == TerrainType.ROAD -> TerrainType.ROAD
+
+            // zweigeteilte Stadtstücke, z.B. N↔E, E↔S, S↔W, W↔N
+            terrains["N"] == TerrainType.CITY && terrains["E"] == TerrainType.CITY -> TerrainType.CITY
+            terrains["E"] == TerrainType.CITY && terrains["S"] == TerrainType.CITY -> TerrainType.CITY
+            terrains["S"] == TerrainType.CITY && terrains["W"] == TerrainType.CITY -> TerrainType.CITY
+            terrains["W"] == TerrainType.CITY && terrains["N"] == TerrainType.CITY -> TerrainType.CITY
+
             else -> null
         }
     }

--- a/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
+++ b/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
@@ -507,7 +507,6 @@ class GameManager {
 
         // Nächster Spielstatus
         game.status = GamePhase.SCORING //Mike: Ist das richtig oder müssen wir auf SCORING? --> Scoring lt. Bespr. mit Jakob/Felix 27.04.2025
-        game.nextPlayer() //TODO: Mike: Check mit Jakob/Felix, ob ich überhaupt auf nextPlayer stellen darf!
 
         return game
     }

--- a/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
+++ b/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
@@ -322,6 +322,7 @@ class GameManager {
         }
 
         //game.nextPlayer() move to endTurn logic
+        game.status = GamePhase.MEEPLE_PLACEMENT
         return game
     }
 
@@ -608,16 +609,18 @@ class GameManager {
         return game
     }
 
-    private fun isValidMeeplePosition(tile: Tile, position: MeeplePosition): Boolean {
-        if (position == MeeplePosition.C) {
-            return tile.isMonastery()
+    private fun isValidMeeplePosition(tile: Tile, pos: MeeplePosition): Boolean {
+        val terrain = tile.getTerrainAtOrNull(pos) ?: return false
+        return when (pos) {
+            MeeplePosition.C -> terrain in listOf(
+                TerrainType.MONASTERY,
+                TerrainType.ROAD,
+                TerrainType.CITY
+            )
+            else -> terrain == TerrainType.ROAD || terrain == TerrainType.CITY
         }
-
-        val rotatedTerrains = tile.getRotatedTerrains()
-        val terrain = rotatedTerrains[position.name] ?: return false
-
-        return terrain == TerrainType.CITY || terrain == TerrainType.ROAD
     }
+
 
     fun getConnectedFeatureTiles(game: GameState, startTile: Tile, startPosition: MeeplePosition): List<Position> {
         val visited = mutableSetOf<Position>()

--- a/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
+++ b/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
@@ -505,6 +505,9 @@ class GameManager {
         meeple.position = position
         game.meeplesOnBoard.add(meeple)
 
+        // Meeple-Anzahl aktualisieren
+        currentPlayer.remainingMeeple -= 1
+
         // Nächster Spielstatus
         game.status = GamePhase.SCORING //Mike: Ist das richtig oder müssen wir auf SCORING? --> Scoring lt. Bespr. mit Jakob/Felix 27.04.2025
 
@@ -579,7 +582,7 @@ class GameManager {
     }
 
     fun createGameWithHost(gameId: String, hostName: String): GameState {
-        val host = Player(hostName, 0, 8, 0)
+        val host = Player(hostName, 0, 7, 0)
         val game = GameState(gameId)
 
         val fullDeck = createShuffledTileDeck(System.currentTimeMillis()).toMutableList()

--- a/src/test/kotlin/com/carcassonne/backend/service/GameManagerTest.kt
+++ b/src/test/kotlin/com/carcassonne/backend/service/GameManagerTest.kt
@@ -373,6 +373,40 @@ class GameManagerTest {
     }
 
     @Test
+    fun `should reduce remainingMeeples after valid first meeple placement`() {
+        val gameId = "meeple-reduction-test"
+        val game = gameManager.getOrCreateGame(gameId)
+
+        // Spiel vorbereiten
+        game.addPlayer("Player1")
+        game.addPlayer("Player2")
+        game.startGame()
+
+        val player = game.players.first { it.id == "Player1" }
+        assertEquals(7, player.remainingMeeple, "Initialer Meeple-Stand sollte 7 sein")
+
+        // Platzieren eines Tiles
+        val tile = Tile(
+            id = "tile-start",
+            terrainNorth = TerrainType.FIELD,
+            terrainEast = TerrainType.ROAD,
+            terrainSouth = TerrainType.CITY,
+            terrainWest = TerrainType.FIELD,
+            tileRotation = TileRotation.NORTH,
+            position = Position(0, 0)
+        )
+        gameManager.placeTile(gameId, tile, "Player1")
+
+        // Meeple setzen
+        val meeple = Meeple(id = "meeple-001", playerId = "Player1", tileId = tile.id)
+        gameManager.placeMeeple(gameId, "Player1", meeple, MeeplePosition.S)
+
+        // Überprüfen, ob der Meeple-Zähler reduziert wurde
+        val updatedPlayer = game.players.first { it.id == "Player1" }
+        assertEquals(6, updatedPlayer.remainingMeeple, "Meeple-Zähler sollte nach Platzierung 6 sein")
+    }
+
+    @Test
     fun `should not allow meeple placement when player has no meeples left`() {
         val gameId = "meeple-no-meeple-test"
         val game = gameManager.getOrCreateGame(gameId)
@@ -482,6 +516,7 @@ class GameManagerTest {
         assertNotNull(updatedGameState, "Meeple should be placed successfully")
         assertTrue(updatedGameState!!.meeplesOnBoard.contains(meepleValid))
 
+        game.nextPlayer()
         game.status = GamePhase.TILE_PLACEMENT
 
         // Tile ohne Kloster
@@ -541,6 +576,7 @@ class GameManagerTest {
             Meeple(id = "m1", playerId = "Player1", tileId = "city-1"),
             MeeplePosition.N
         )
+        game.nextPlayer()
         game.status = GamePhase.TILE_PLACEMENT
         //Runde 2
         gameManager.placeTile(gameId,cityTile2,"Player2")

--- a/src/test/kotlin/com/carcassonne/backend/service/GameManagerTest.kt
+++ b/src/test/kotlin/com/carcassonne/backend/service/GameManagerTest.kt
@@ -366,10 +366,9 @@ class GameManagerTest {
     @Test
     fun `should reduce remainingMeeples after valid first meeple placement`() {
         val gameId = "meeple-reduction-test"
-        val game = gameManager.getOrCreateGame(gameId)
+        val game = gameManager.createGameWithHost(gameId, "Player1")
 
         // Spiel vorbereiten
-        game.addPlayer("Player1")
         game.addPlayer("Player2")
         game.startGame()
 


### PR DESCRIPTION
###   What’s new
* **GameManager**
  * Switches game phases (TILE → MEEPLE → SCORING)
  * Adds terrain-aware validation for Meeple placement
* **Tile**
  * Helper `getTerrainAtOrNull()` (rotations + monastery / road / city centre)
* **Meeple**
  * removed unused MeepleType from Meeple
* **GameWebSocketController**
  * Adds `gamePhase` field to both `board_update` and `meeple_placed`
  * Minor robustness tweaks for invalid placement errors
* **feat: Standardize Meeple count logic and update placement behavior**
  *  Standardizes Meeple-count logic and propagates remainingMeeple to the client.
  * Players now always start with 7 Meeples; after each valid placement the backend decrements remainingMeeple and returns the new value in the WebSocket payload (tests updated accordingly).

### Issues
* refs #44
* closes #35 