### PR TITLE
Finish Turn-Based Flow, Add Draw Enforcement, Sync GamePhase

### DIFF
--- a/src/main/kotlin/com/carcassonne/backend/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/carcassonne/backend/config/WebSocketConfig.kt
@@ -1,5 +1,7 @@
 package com.carcassonne.backend.config
 import com.carcassonne.backend.security.JwtHandshakeInterceptor
+import com.carcassonne.backend.security.UserHandshakeHandler
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
@@ -12,10 +14,14 @@ class WebSocketConfig(
     private val customHandshakeInterceptor: JwtHandshakeInterceptor
 ) : WebSocketMessageBrokerConfigurer {
 
+    @Bean
+    fun userHandshakeHandler() = UserHandshakeHandler()
+
     override fun registerStompEndpoints(registry: StompEndpointRegistry) {
         registry.addEndpoint("/ws/game")
             .setAllowedOriginPatterns("*")
             .addInterceptors(customHandshakeInterceptor)
+            .setHandshakeHandler(userHandshakeHandler())
     }
 
     override fun configureMessageBroker(registry: MessageBrokerRegistry) {

--- a/src/main/kotlin/com/carcassonne/backend/controller/GameWebSocketController.kt
+++ b/src/main/kotlin/com/carcassonne/backend/controller/GameWebSocketController.kt
@@ -367,7 +367,8 @@ class GameWebSocketController(
                     "remainingMeeple" to p.remainingMeeple
                 )
             },
-            "nextPlayer" to game.getCurrentPlayer()
+            "nextPlayer" to game.getCurrentPlayer(),
+            "gamePhase"  to game.status.name
         )
         messagingTemplate.convertAndSend("/topic/game/${game.gameId}", scorePayload)
     }

--- a/src/main/kotlin/com/carcassonne/backend/controller/GameWebSocketController.kt
+++ b/src/main/kotlin/com/carcassonne/backend/controller/GameWebSocketController.kt
@@ -93,6 +93,14 @@ class GameWebSocketController(
                 println(">>> [Backend] Sending game_started to /topic/game/${msg.gameId} with $payload")
                 messagingTemplate.convertAndSend("/topic/game/${msg.gameId}", payload)
 
+                // Deck counter initialization
+                messagingTemplate.convertAndSend("/topic/game/${msg.gameId}",
+                    mapOf(
+                        "type" to "deck_update",
+                        "deckRemaining" to game.tileDeck.size
+                    )
+                )
+
                 val startTile = game.board[Position(0, 0)]
                     ?: throw IllegalStateException("Starting tile missing in game ${msg.gameId}")
 

--- a/src/main/kotlin/com/carcassonne/backend/model/GameState.kt
+++ b/src/main/kotlin/com/carcassonne/backend/model/GameState.kt
@@ -8,7 +8,8 @@ data class GameState(
     var status: GamePhase = GamePhase.WAITING,
     var discardedTiles: MutableList<Tile> = mutableListOf(),
     var tileDeck: MutableList<Tile> = mutableListOf(), // The tile deck can be managed here.
-    val meeplesOnBoard: MutableList<Meeple> = mutableListOf() // Liste der platzierten Meeples
+    val meeplesOnBoard: MutableList<Meeple> = mutableListOf(), // Liste der platzierten Meeples
+    var tileDrawnThisTurn: Boolean = false
 ) {
     // Switch to the next player
     fun nextPlayer(): String {

--- a/src/main/kotlin/com/carcassonne/backend/security/UserHandshakeHandler.kt
+++ b/src/main/kotlin/com/carcassonne/backend/security/UserHandshakeHandler.kt
@@ -1,0 +1,22 @@
+package com.carcassonne.backend.security
+
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.web.socket.WebSocketHandler
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler
+import java.security.Principal
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+
+class UserHandshakeHandler : DefaultHandshakeHandler() {
+
+    override fun determineUser(
+        request: ServerHttpRequest,
+        wsHandler: WebSocketHandler,
+        attributes: MutableMap<String, Any>
+    ): Principal? {
+
+        val username = attributes["username"] as? String
+            ?: return super.determineUser(request, wsHandler, attributes)
+
+        return UsernamePasswordAuthenticationToken(username, null, emptyList())
+    }
+}

--- a/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
+++ b/src/main/kotlin/com/carcassonne/backend/service/GameManager.kt
@@ -174,12 +174,11 @@ class GameManager {
                          else -> ""
                      }
 
-                     // 6. Punkte vergeben & Meeples entfernen
+                     // 6. Punkte vergeben, Meeples vom Brett entfernen und den Spielern zurückgeben
                      awardPoints(game, involvedMeeples, featureTiles.size, featureTypeString)
                      game.meeplesOnBoard.removeAll(involvedMeeples)
-                     game.nextPlayer()
-                     if(game.status == GamePhase.SCORING) {
-                         game.status = GamePhase.TILE_PLACEMENT
+                     involvedMeeples.forEach { meeple ->
+                         game.players.first { it.id == meeple.playerId }.remainingMeeple++
                      }
                  }
              }


### PR DESCRIPTION
- Centralize end‑of‑turn flow: Added finalizeTurn() (with skip_meeple) to handle scoring, meeple return, phase reset (SCORING→TILE_PLACEMENT) and nextPlayer() in one place.

- Enforce single draw per turn: Introduced tileDrawnThisTurn guard and enhanced logging to prevent duplicate DRAW_TILE requests.

- Improve deck & draw messaging: Restricted TILE_DRAWN events to the drawing player’s private queue; broadcast deck_update globally; initialized deck counters during start_game.

- Fix phase sync bug: Included "gamePhase": "TILE_PLACEMENT" in score_update payload so clients reliably switch back to tile‑placement for the next player.